### PR TITLE
Bugfix: parsing of plugins.d failed with some file-systems

### DIFF
--- a/ambd/pluginloader.cpp
+++ b/ambd/pluginloader.cpp
@@ -187,7 +187,8 @@ void PluginLoader::scanPluginDir(const std::string & dir)
 
     GError* enumerateError = nullptr;
 
-    auto enumerator = amb::make_gobject(g_file_enumerate_children(pluginsDirectory.get(), G_FILE_ATTRIBUTE_ID_FILE,
+    auto enumerator = amb::make_gobject(g_file_enumerate_children(pluginsDirectory.get(),
+                                                                  G_FILE_ATTRIBUTE_ID_FILE "," G_FILE_ATTRIBUTE_STANDARD_NAME,
                                                                   G_FILE_QUERY_INFO_NONE, nullptr,
                                                                   &enumerateError));
     auto enumerateErrorPtr = amb::make_super(enumerateError);


### PR DESCRIPTION
Missing G_FILE_ATTRIBUTE_STANDARD_NAME flag in the call to g_file_enumerate_children(). 
As we need the names of the files (to open them), we need to add this flag, even if on most file-systems, the filenames are fetched by default. For some file-systems like NFS, this flag is required. Without it, AMB crashes.