### PR TITLE
cmake: assorted install path fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,10 @@ add_definitions(-DPROJECT_SERIES="${PROJECT_SERIES}")
 
 set (LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)" )
 set (LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" )
-set (PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}")
+set (PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}")
 set (INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 set (DOC_INSTALL_DIR "${CMAKE_INSTALL_DOCDIR}/${PROJECT_SERIES}")
-set (PLUGIN_SEGMENT_INSTALL_PATH "/${CMAKE_INSTALL_SYSCONFDIR}/ambd/plugins.d")
+set (PLUGIN_SEGMENT_INSTALL_PATH "${CMAKE_INSTALL_SYSCONFDIR}/ambd/plugins.d")
 
 option(qtmainloop "Use QCoreApplication mainloop " OFF)
 option(websocket_plugin "websocket source and sink plugins" OFF)

--- a/plugins/dbus/amb-qt/CMakeLists.txt
+++ b/plugins/dbus/amb-qt/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(ambqtquick amb-qt ${QT_LIBRARIES} -L${CMAKE_CURRENT_BINARY
 add_executable(ambtestclient test.cpp)
 target_link_libraries(ambtestclient amb amb-qt ${QT_LIBRARIES} -L${CMAKE_CURRENT_BINARY_DIR}/lib ${link_libraries} ${gio_LIBRARIES})
 
-install (TARGETS amb-qt LIBRARY DESTINATION lib${LIB_SUFFIX})
+install (TARGETS amb-qt LIBRARY DESTINATION ${LIB_INSTALL_DIR})
 
 install (FILES ${ambqt_headers} DESTINATION ${INCLUDE_INSTALL_DIR}/ COMPONENT Devel)
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/qmldir DESTINATION ${LIB_INSTALL_DIR}/qt5/qml/amb COMPONENT Devel)


### PR DESCRIPTION
- Avoid double prefix in PLUGIN_INSTALL_PATH
- Avoid leading "//" in PLUGIN_SEGMENT_INSTALL_PATH - cmake will think
  it's a network directory
- Use installation directory variable in amb-qt installation

Signed-off-by: Frederico Cadete <frederico.cadete@awtce.be>