### PR TITLE
AmbSignalMapper: bugfix about configuration

### DIFF
--- a/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_plugin.cpp
+++ b/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_plugin.cpp
@@ -103,7 +103,7 @@ AmbTmplPlugin::AmbTmplPlugin(AbstractRoutingEngine* re, const map<string, string
     if (it != config.end() && it->second.length())
         announcementCount = atoi(std::string(it->second).c_str());
     if(announcementCount < 1)
-            announcementIntervalTimer = 1;
+            announcementCount = 1;
 
     registerMessages();
 }


### PR DESCRIPTION
If 'announcementCount' variable is lower than 1, then
'announcementIntervalTimer' variable is updated to 1. That is definitely
a bug so this patch fixes that error by updating 'announcementCount'
instead of 'announcementIntervalTimer'.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>