### PR TITLE
AmbSignalMapper: clean up the warning message

### DIFF
--- a/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_cansignal.cpp
+++ b/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_cansignal.cpp
@@ -125,6 +125,8 @@ bool CANSignal::updateFrame(can_frame* frame)
     int64_t bits = conversionFunctionTo(val, static_cast<int64_t>(temp));
 
     *(reinterpret_cast<uint64_t*>(&frame->data[0])) |= toSignalBits(bits);
+
+    return true;
 }
 
 int64_t CANSignal::getSignalBits( const can_frame& frame )

--- a/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_cansignal.h
+++ b/tools/AmbSignalMapper/lib/Intel/IviPoc/templates/ambtmpl_cansignal.h
@@ -242,7 +242,7 @@ private:
     } \
     uint64_t conversionFunctionTo(double value, uint64_t bits) { \
         if(convertToFunction) \
-            convertToFunction(convert<valueType>(value), bits); \
+            return convertToFunction(convert<valueType>(value), bits); \
         else return bits; \
     } \
     valueType m_minValue; \


### PR DESCRIPTION
Some generated functions by AmbSignalMapper do not return the result
even it is not a void function. Because of this reason, below error
occurs when build it. This patch fixes this bug.

---------------------------------------------------------------------
warning: control reaches end of non-void function [-Wreturn-type]
---------------------------------------------------------------------

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>