### PR TITLE
fixed all warning messages when enabling -Wall option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(QMAKE_INSTALL_PATH "/usr/bin/qmake" CACHE PATH "qmake executable path")
 
 #turn on -fpic/-fpie:
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpie -pie -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpie -pie -std=c++14 -Wall")
 
 if (enable_icecc)
 	include (CMakeForceCompiler)

--- a/ambd/pluginloader.cpp
+++ b/ambd/pluginloader.cpp
@@ -48,7 +48,7 @@ std::string get_file_contents(const char *filename)
     return output;
 }
 
-PluginLoader::PluginLoader(string configFile, int argc, char** argv): f_create(NULL), routingEngine(nullptr), mMainLoop(nullptr)
+PluginLoader::PluginLoader(string configFile, int argc, char** argv): routingEngine(nullptr), f_create(NULL), mMainLoop(nullptr)
 {
     DebugOut()<<"Loading config file: "<<configFile<<endl;
     std::string configBuffer = get_file_contents(configFile.c_str());

--- a/lib/abstractpropertytype.h
+++ b/lib/abstractpropertytype.h
@@ -604,11 +604,13 @@ public:
 	BasicPropertyType & operator ++ ()
 	{
 		setValue(basicValue() + 1);
+		return *this;
 	}
 
 	BasicPropertyType & operator -- ()
 	{
 		setValue(basicValue() - 1);
+		return *this;
 	}
 
 	bool operator < (const BasicPropertyType<T>& other) const
@@ -830,6 +832,8 @@ public:
 		picojson::object obj = val.get<picojson::object>();
 
 		obj["value"] = amb::gvariantToJson(toVariant());
+
+		return picojson::value(obj);
 	}
 
 	virtual void fromJson(const picojson::value &json)
@@ -1006,7 +1010,7 @@ public:
 
 		/// TODO: fill this in
 		gsize dictsize = g_variant_n_children(v);
-		for (int i=0;i<dictsize;i++)
+		for (gsize i=0;i<dictsize;i++)
 		{
 			GVariant *childvariant = g_variant_get_child_value(v,i);
 			GVariant *innervariant = g_variant_get_variant(childvariant);

--- a/lib/abstractroutingengine.cpp
+++ b/lib/abstractroutingengine.cpp
@@ -26,19 +26,19 @@ AbstractRoutingEngine::~AbstractRoutingEngine()
 }
 
 AsyncPropertyReply::AsyncPropertyReply()
-	:AsyncPropertyRequest(), value(nullptr), success(false), timeoutSource(nullptr), timedout(nullptr)
+	:AsyncPropertyRequest(), value(nullptr), success(false), timedout(nullptr), timeoutSource(nullptr)
 {
 	setTimeout();
 }
 
 AsyncPropertyReply::AsyncPropertyReply(const AsyncPropertyRequest &request)
-	:AsyncPropertyRequest(request), value(NULL), success(false), timeoutSource(nullptr), timedout(nullptr)
+	:AsyncPropertyRequest(request), value(NULL), success(false), timedout(nullptr), timeoutSource(nullptr)
 {
 	setTimeout();
 }
 
 AsyncPropertyReply::AsyncPropertyReply(const AsyncSetPropertyRequest &request)
-	:AsyncPropertyRequest(request), value(request.value), success(false), timeoutSource(nullptr), timedout(nullptr)
+	:AsyncPropertyRequest(request), value(request.value), success(false), timedout(nullptr), timeoutSource(nullptr)
 {
 	setTimeout();
 	if(value)

--- a/lib/asyncqueue.hpp
+++ b/lib/asyncqueue.hpp
@@ -34,7 +34,7 @@ class Queue
 {
 public:
 	Queue(bool unique = false, bool blocking = false)
-		:mUnique(unique), mBlocking(blocking)
+		:mBlocking(blocking), mUnique(unique)
 	{
 
 	}

--- a/lib/listplusplus.cpp
+++ b/lib/listplusplus.cpp
@@ -23,7 +23,7 @@
 std::string::size_type amb::count(const std::string & t, const std::string & toFind, const std::string &before)
 {
 	int count = 0;
-	int pos = -1;
+	size_t pos = -1;
 
 	std::string::size_type beforePos = t.find(before);
 
@@ -37,9 +37,9 @@ std::string::size_type amb::count(const std::string & t, const std::string & toF
 
 int amb::findNth(const std::string & t, const std::string & toFind, std::string::size_type n)
 {
-	int count = 0;
+	size_t count = 0;
 	auto itr = t.begin();
-	for(itr; count < n; itr++, count++)
+	for(; count < n; itr++, count++)
 	{
 		if(itr == t.end())
 			break;

--- a/lib/mappropertytype.hpp
+++ b/lib/mappropertytype.hpp
@@ -103,7 +103,7 @@ public:
 	{
 		clear();
 		gsize dictsize = g_variant_n_children(variant);
-		for (int i=0;i<dictsize;i++)
+		for (gsize i=0;i<dictsize;i++)
 		{
 			GVariant *childvariant = g_variant_get_child_value(variant,i);
 			gsize dictvalsize = g_variant_n_children(childvariant);

--- a/lib/vehicleproperty.cpp
+++ b/lib/vehicleproperty.cpp
@@ -137,8 +137,6 @@ const VehicleProperty::Property VehicleProperty::AccelerationX = "AccelerationX"
 const VehicleProperty::Property VehicleProperty::AccelerationY = "AccelerationY";
 const VehicleProperty::Property VehicleProperty::AccelerationZ = "AccelerationZ";
 const VehicleProperty::Property VehicleProperty::MassAirFlow = "MassAirFlow";
-[[deprecated("Deprecated in 0.14.  Use ButtonEventW3C")]]
-const VehicleProperty::Property VehicleProperty::ButtonEvent = "ButtonEvent";
 const VehicleProperty::Property VehicleProperty::AirIntakeTemperature = "AirIntakeTemperature";
 const VehicleProperty::Property VehicleProperty::BatteryVoltage = "BatteryVoltage";
 const VehicleProperty::Property VehicleProperty::BatteryCurrent = "BatteryCurrent";
@@ -330,7 +328,6 @@ VehicleProperty::VehicleProperty()
 	REGISTERPROPERTY(AccelerationY, 0);
 	REGISTERPROPERTY(AccelerationZ, 0);
 	REGISTERPROPERTY(MassAirFlow, 0);
-	REGISTERPROPERTY(ButtonEvent, ButtonEvents::NoButton);
 	REGISTERPROPERTY(AirIntakeTemperature, 0)
 	REGISTERPROPERTY(BatteryVoltage, 0);
 	REGISTERPROPERTY(BatteryCurrent, 0);

--- a/plugins/common/abstractdbusinterface.cpp
+++ b/plugins/common/abstractdbusinterface.cpp
@@ -237,7 +237,7 @@ void AbstractDBusInterface::handleMyMethodCall(GDBusConnection       *connection
 
 AbstractDBusInterface::AbstractDBusInterface(string interfaceName, string objectName,
 											 GDBusConnection* connection)
-	: mInterfaceName(interfaceName), mConnection(connection), mPropertyName(objectName), supported(false), zoneFilter(Zone::None), mTime(0), regId(0)
+	: zoneFilter(Zone::None), supported(false), mTime(0), mInterfaceName(interfaceName), mPropertyName(objectName), mConnection(connection), regId(0)
 {
 	startRegistration();
 

--- a/plugins/common/bluetooth5.cpp
+++ b/plugins/common/bluetooth5.cpp
@@ -200,9 +200,6 @@ std::string findDevice(std::string address, std::string adapterPath)
 Bluetooth5::Bluetooth5()
 {
 	GError* errorIntrospection = NULL;
-
-	GDBusNodeInfo* introspection = g_dbus_node_info_new_for_xml(introspection_xml, &errorIntrospection);
-
 	auto errorIntrospectionPtr = amb::make_super(errorIntrospection);
 
 	if(errorIntrospectionPtr)
@@ -212,9 +209,6 @@ Bluetooth5::Bluetooth5()
 	}
 
 	GError* errorBus = nullptr;
-
-	GDBusInterfaceInfo* mInterfaceInfo = g_dbus_node_info_lookup_interface(introspection, "org.bluez.Profile1");
-
 	mConnection = amb::make_super(g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &errorBus));
 
 	auto errorBusPtr = amb::make_super(errorBus);
@@ -226,11 +220,7 @@ Bluetooth5::Bluetooth5()
 	}
 
 	GError* errorRegister = nullptr;
-
-	int regId = g_dbus_connection_register_object(mConnection.get(), "/org/bluez/spp", mInterfaceInfo, &interfaceVTable, this, NULL, &errorRegister);
-
 	auto errorRegisterPtr = amb::make_super(errorRegister);
-
 	if(errorRegisterPtr)
 	{
 

--- a/plugins/common/dbusplugin.cpp
+++ b/plugins/common/dbusplugin.cpp
@@ -29,8 +29,8 @@
 std::map<std::string, std::string> DBusSink::dbusConfig;
 
 DBusSink::DBusSink(std::string propertyName, AbstractRoutingEngine* engine, GDBusConnection* connection, std::map<std::string, std::string> config)
-	:AbstractDBusInterface("org.automotive."+propertyName, propertyName, connection),
-	  AbstractSink(engine, dbusConfig)
+	: AbstractSink(engine, dbusConfig),
+	AbstractDBusInterface("org.automotive."+propertyName, propertyName, connection)
 {
 	AbstractDBusInterface::re = engine;
 

--- a/plugins/common/jsonprotocol.cpp
+++ b/plugins/common/jsonprotocol.cpp
@@ -404,7 +404,7 @@ bool amb::BaseJsonMessageReader::hasJson()
 		incompleteMessage = incompleteMessage.substr(start-1);
 	}
 
-	int end = incompleteMessage.find("\n");
+	unsigned int end = incompleteMessage.find("\n");
 
 	if(end == std::string::npos)
 	{
@@ -578,6 +578,7 @@ bool amb::GetMethodCall::fromJson(const picojson::value &json)
 	MethodCall::fromJson(json);
 
 	value = Object::fromJson(json.get("data").get<picojson::object>());
+	return true;
 }
 
 

--- a/plugins/common/jsonprotocol.h
+++ b/plugins/common/jsonprotocol.h
@@ -170,7 +170,7 @@ class MethodReply
 public:
 
 	MethodReply(): MethodReply(nullptr, false) {}
-	MethodReply(std::shared_ptr<T> t, bool success): mMethod(t), methodSuccess(success), err(AsyncPropertyReply::NoError) { }
+	MethodReply(std::shared_ptr<T> t, bool success): methodSuccess(success), mMethod(t), err(AsyncPropertyReply::NoError) { }
 	bool methodSuccess;
 
 	picojson::value toJson()

--- a/plugins/common/varianttype.cpp
+++ b/plugins/common/varianttype.cpp
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <listplusplus.h>
 
 VariantType::VariantType(AbstractRoutingEngine* re, VehicleProperty::Property ambPropertyName, std::string propertyName,  Access access)
-	:mPropertyName(propertyName), mAccess(access), mValue(nullptr), mZoneFilter(Zone::None), mUpdateFrequency(0), mInitialized(false)
+	:mZoneFilter(Zone::None), mUpdateFrequency(0), mPropertyName(propertyName), mAccess(access), mValue(nullptr), mInitialized(false)
 {
 	mAmbPropertyName = ambPropertyName;
 	routingEngine = re;

--- a/plugins/examplesink.cpp
+++ b/plugins/examplesink.cpp
@@ -41,12 +41,6 @@ ExampleSink::ExampleSink(AbstractRoutingEngine* engine, map<string, string> conf
 	supportedChanged(engine->supported());
 }
 
-
-PropertyList ExampleSink::subscriptions()
-{
-
-}
-
 void ExampleSink::supportedChanged(const PropertyList & supportedProperties)
 {
 	DebugOut()<<"Support changed!"<<endl;

--- a/plugins/testplugin/testplugin.cpp
+++ b/plugins/testplugin/testplugin.cpp
@@ -316,6 +316,8 @@ bool TestPlugin::testSetAndGet()
 
 	TEST(replySuccess == true);
 	TEST(replyError == AsyncPropertyReply::NoError);
+
+	return replySuccess;
 }
 
 bool TestPlugin::testCoreUpdateSupported()
@@ -373,8 +375,6 @@ TestPlugin::TestPlugin(AbstractRoutingEngine *re, map<string, string> config)
 	MapPropertyType<BasicPropertyType<Door::Status>> propmaptwo("SomethingElse");
 	propmap.append("hi", Door::Ajar);
 	GVariant *var = propmap.toVariant();
-	gsize dictsize = g_variant_n_children(var);
-	//DebugOut() << var << endl;
 	propmaptwo.fromVariant(var);
 
 	g_assert(propmaptwo.toString() == propmap.toString());

--- a/plugins/wheel/wheelplugin.cpp
+++ b/plugins/wheel/wheelplugin.cpp
@@ -143,11 +143,6 @@ void WheelSourcePlugin::getPropertyAsync(AsyncPropertyReply *reply)
 	reply->completed(reply);
 }
 
-AsyncPropertyReply *WheelSourcePlugin::setProperty(AsyncSetPropertyRequest request )
-{
-
-}
-
 void WheelSourcePlugin::subscribeToPropertyChanges(VehicleProperty::Property property)
 {
 	mRequests.insert(property);
@@ -207,21 +202,21 @@ void readCallback(GObject *srcObj, GAsyncResult *res, gpointer userData)
 
 WheelPrivate::WheelPrivate(WheelSourcePlugin *parent, AbstractRoutingEngine *route)
 	:re(route), gis(nullptr), axis(nullptr), button(nullptr),
+	  machineGuns(new VehicleProperty::MachineGunTurretStatusType(false)),
+	  vehicleSpeed(new VehicleProperty::VehicleSpeedType(0)),
+	  engineSpeed(new VehicleProperty::EngineSpeedType(0)),
+	  turnSignal(new VehicleProperty::TurnSignalType(TurnSignals::Off)),
+	  shiftPosition(new VehicleProperty::TransmissionShiftPositionType(Transmission::Neutral)),
+	  gearPosition(new VehicleProperty::TransmissionGearPositionType(Transmission::Neutral)),
 	  oilPSI(new VehicleProperty::EngineOilPressureType(10)),
 	  coolantTemp(new VehicleProperty::EngineCoolantTemperatureType(100)),
-	  turnSignal(new VehicleProperty::TurnSignalType(TurnSignals::Off)),
-	  throttle(new VehicleProperty::ThrottlePositionType(0)),
-	  machineGuns(new VehicleProperty::MachineGunTurretStatusType(false)),
-	  gearPosition(new VehicleProperty::TransmissionGearPositionType(Transmission::Neutral)),
-	  shiftPosition(new VehicleProperty::TransmissionShiftPositionType(Transmission::Neutral)),
-	  engineSpeed(new VehicleProperty::EngineSpeedType(0)),
-	  vehicleSpeed(new VehicleProperty::VehicleSpeedType(0)),
 	  steeringAngle(new VehicleProperty::SteeringWheelAngleType(0)),
 	  steeringAngleW3C(new VehicleProperty::SteeringWheelAngleW3CType(0)),
+	  throttle(new VehicleProperty::ThrottlePositionType(0)),
 	  clutch(new VehicleProperty::ClutchStatusType(false)),
 	  brake(new VehicleProperty::WheelBrakeType(false)),
-	  tempButton(new VehicleProperty::ButtonEventType(ButtonEvents::NoButton)),
-	  mParent(parent)
+	  mParent(parent),
+	  tempButton(new VehicleProperty::ButtonEventType(ButtonEvents::NoButton))
 {
 
 	unsigned char numAxes = 0;


### PR DESCRIPTION
I found out that there were many warning messages when compiling the ABM with '-Wall' option.
Those could be potential risk factors so should be removed. This patch fixed the below warning messages.
* warning: comparison between signed and unsigned integer expressions
* warning: no return statement in function returning non-void
* warning: statement has no effect
* warning: unused variable
* warning: when initialized here [-Wreorder]
* warning: control reaches end of non-void function [-Wreturn-type]
* warning: ‘VehicleProperty::ButtonEvent’ is deprecated: Deprecated in
                 0.14.  Use ButtonEventW3C [-Wdeprecated-declarations]
